### PR TITLE
Add EHIS eeIsikukaart subservice

### DIFF
--- a/lib/x_road/services/ehis.rb
+++ b/lib/x_road/services/ehis.rb
@@ -30,12 +30,13 @@ module XRoad
       # XRoad::Ehis.isikukaart('39203086818')
       # XRoad::Ehis.isikukaart('39409060827')
       #
-      def isikukaart(personal_code, user_id:)
+      def isikukaart(personal_code)
         service_path = producer_path + '/eeIsikukaart/v1'
         body = {
           isikukood: personal_code
         }
-        request service_path: service_path, body: body, user_id: user_id
+        # UserID 'EE11111111111' is ment for system-queries
+        request service_path: service_path, body: body, user_id: 'EE11111111111'
       end
 
       #

--- a/lib/x_road/services/ehis.rb
+++ b/lib/x_road/services/ehis.rb
@@ -26,10 +26,11 @@ module XRoad
 
       #
       # Example usage:
-      # XRoad::Ehis.isikukaart('60510319579')
-      # XRoad::Ehis.isikukaart('37803312007')
+      # XRoad::Ehis.isikukaart('39205182750')
+      # XRoad::Ehis.isikukaart('39203086818')
+      # XRoad::Ehis.isikukaart('39409060827')
       #
-      def isikukaart(personal_code)
+      def isikukaart(personal_code, user_id:)
         service_path = producer_path + '/eeIsikukaart/v1'
         body = {
           isikukood: personal_code

--- a/lib/x_road/services/ehis.rb
+++ b/lib/x_road/services/ehis.rb
@@ -25,6 +25,19 @@ module XRoad
       end
 
       #
+      # Example usage:
+      # XRoad::Ehis.isikukaart('60510319579')
+      # XRoad::Ehis.isikukaart('37803312007')
+      #
+      def isikukaart(personal_code)
+        service_path = producer_path + '/eeIsikukaart/v1'
+        body = {
+          isikukood: personal_code
+        }
+        request service_path: service_path, body: body, user_id: user_id
+      end
+
+      #
       # Example usage: 
       # XRoad::Ehis.tervishoiuametile_oppurid('123', user_id: 'EE37803312007')
       #


### PR DESCRIPTION
EHIS has a subservice called eeIsikukaart which will provide person's educational information based on personal code.
Educational information from eeIsikukaart will describe occupational and higher education graduation and ongoing studying data.